### PR TITLE
remove use of dataset, which is not supported in ie

### DIFF
--- a/rrdgraph.js
+++ b/rrdgraph.js
@@ -2159,7 +2159,7 @@ var RRDGraph = window['RRDGraph'] = {};
   window['RRDGraph']['init'] = function (selector, config_str) {
     var result = [];
     d3.selectAll(selector).each(function () {
-      var src = parseSrc(this.dataset.src);
+      var src = parseSrc(this.getAttribute('data-src'));
       var element = this;
 
       var config;


### PR DESCRIPTION
IE9 doesn't understand the dataset property, this fixes it so rrdgraph.js works with Internet Explorer.
